### PR TITLE
fix UserFriendsService to Sync

### DIFF
--- a/imahima.xcodeproj/xcuserdata/yuki.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/imahima.xcodeproj/xcuserdata/yuki.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>imahima.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>13</integer>
+			<integer>32</integer>
 		</dict>
 	</dict>
 </dict>

--- a/imahima/Controller/MainViewController.swift
+++ b/imahima/Controller/MainViewController.swift
@@ -14,28 +14,35 @@ import FirebaseFirestore
 class MainViewController: UIViewController, KolodaViewDataSource, KolodaViewDelegate {
     @IBOutlet weak var kolodaView: KolodaView!
     
-    var userArray: Array<User> = []
+    var userFriends: Array<User> = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.navigationItem.title = "Main"
 		
-        let dispatchGroup = DispatchGroup()
-        let dispatchQueue = DispatchQueue(label: "queue")
-        dispatchGroup.enter();
+		// Facebookの友人情報を取得
+		let userFriendsService = UserFriendsService()
+		userFriends = userFriendsService.getUserFriends()
+		
+		self.kolodaView.dataSource = self
+		self.kolodaView.delegate = self
+		
+//        let dispatchGroup = DispatchGroup()
+//        let dispatchQueue = DispatchQueue(label: "queue")
+//        dispatchGroup.enter();
 //        dispatchQueue.async(group: dispatchGroup) {
 //            self.getUsers(dg: dispatchGroup)
 //        }
-        
-        dispatchQueue.async(group: dispatchGroup) {
-            self.getUserFriends(dg: dispatchGroup)
-        }
-        
-        dispatchGroup.notify(queue: .main) {
+//
+//        dispatchQueue.async(group: dispatchGroup) {
+//            self.getUserFriends(dg: dispatchGroup)
+//        }
+//
+//        dispatchGroup.notify(queue: .main) {
 //            self.addUsersCollection()
-			self.kolodaView.dataSource = self
-			self.kolodaView.delegate = self
-        }
+//			self.kolodaView.dataSource = self
+//			self.kolodaView.delegate = self
+//        }
     }
     
     func getUsers (dg: DispatchGroup) {
@@ -55,16 +62,6 @@ class MainViewController: UIViewController, KolodaViewDataSource, KolodaViewDele
                 } else {
                     print("no data exists")
                 }
-            }
-            dg.leave()
-        }
-    }
-    
-    func getUserFriends (dg: DispatchGroup) {
-        let userFriendsService = UserFriendsService()
-        userFriendsService.getUserFriends() { users in
-            for user in users {
-                self.userArray.append(User(id: user.id, name: user.name, pictureUrl: user.pictureUrl))
             }
             dg.leave()
         }
@@ -93,7 +90,7 @@ class MainViewController: UIViewController, KolodaViewDataSource, KolodaViewDele
     
     //枚数
     func kolodaNumberOfCards(_ koloda: KolodaView) -> Int {
-        return userArray.count
+        return userFriends.count
     }
     
     //ドラッグのスピード
@@ -114,13 +111,13 @@ class MainViewController: UIViewController, KolodaViewDataSource, KolodaViewDele
 		
         let imageView = UIImageView(frame: koloda.bounds)
         imageView.contentMode = .scaleAspectFit
-		let pictureUrl = userArray[index].pictureUrl
+		let pictureUrl = userFriends[index].pictureUrl
         imageView.image = getImageByUrl(url: pictureUrl)
 		
 		view.addSubview(imageView)
 		
         let label = UILabel()
-		label.text = userArray[index].name
+		label.text = userFriends[index].name
 		view.addSubview(label)
 		label.frame = CGRect(x:0,y:0,width:200,height:100)
 		label.center = CGPoint(x:screenWidth/2,y:screenHeight/2 - 25)
@@ -147,7 +144,7 @@ class MainViewController: UIViewController, KolodaViewDataSource, KolodaViewDele
     func kolodaDidRunOutOfCards(_ koloda: KolodaView) {
         print("Finish cards.")
         //シャッフル
-        userArray = userArray.shuffled()
+        userFriends = userFriends.shuffled()
         //リスタート
         koloda.resetCurrentCardIndex()
     }

--- a/imahima/Model/UserFriendsService.swift
+++ b/imahima/Model/UserFriendsService.swift
@@ -8,9 +8,14 @@
 
 import FBSDKCoreKit
 
+/*
+Facebook APIの me/friends エンドポイントの結果を取得するクラス
+リクエストを行うライブラリは非同期処理だが，この結果を後続処理で使うため同期処理にした
+*/
 class UserFriendsService {
-	var users: Array<User> = []
-	func getUserFriends(callback: @escaping (Array<User>) -> Void) {
+	func getUserFriends() -> Array<User> {
+		var keepAlive = true
+		var userFriends: Array<User> = []
         let graphRequest : GraphRequest =
             GraphRequest(graphPath: "me/friends",
 						 parameters: ["fields": "id, first_name, last_name, name, picture.type(large)"])
@@ -28,11 +33,14 @@ class UserFriendsService {
 					let picture: NSDictionary = friendDic.object(forKey: "picture") as! NSDictionary
 					let data: NSDictionary = picture.object(forKey: "data") as! NSDictionary
 					let pictureUrl: String = data.object(forKey: "url") as! String
-					self.users.append(User(id: id, name: name, pictureUrl: pictureUrl))
+					userFriends.append(User(id: id, name: name, pictureUrl: pictureUrl))
 				}
-				return callback(self.users)
+				keepAlive = false
 			}
 		})
+		let runLoop = RunLoop.current
+		while keepAlive && runLoop.run(mode: RunLoop.Mode.default, before: Date(timeIntervalSinceNow: 0.1)) {}
+		return userFriends
 	}
 
 }


### PR DESCRIPTION
UserFriendsService::getUserFriends()の結果を直後のfirestore引きにいく際に使うため，非同期のままだとこの処理をmain threadで単体waitするような形になってしまう．
(現状のコードだと↓みたいにする必要がある)
```
// 適当なスレッドで実行
let dispatchGroup = DispatchGroup()
let dispatchQueue = DispatchQueue(label: "queue")
dispatchGroup.enter();
dispatchQueue.async(group: dispatchGroup) {
    self.getUserFriends(dg: dispatchGroup)
}
// メインスレッドで取得を待つ
dispatchGroup.notify(queue: .main) {
    後続処理
　firestoreも非同期なのでこの先もdispatchGroupで書いてく必要がある．
}
```

dispatch_semaphoreはmain thread？らしく，copletionHandlerもmain threadなので中で止まってデッドロックになってしまっていた．．
いろいろ調べたらNsRunLoopだといけるらしい．なのでなんか別スレッド立ててるのかな？少なくともcopletionHandlerとは別スレッド．
whileの部分は0.1秒ごとにkeepAliveみてるだけ．
