### PR TITLE
firebase と チャット機能の連携

### DIFF
--- a/imahima/Controller/ChatRoomViewController.swift
+++ b/imahima/Controller/ChatRoomViewController.swift
@@ -10,12 +10,18 @@ import UIKit
 
 class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
-    let chatRoomList = ["yugoto", "stakeshi"]
+//    let chatRoomList = ["yugoto", "stakeshi"]
+    var chatRoomList: Array<ChatRoom> = []
+    var userFriends: Array<User> = []
+    let fireStoreService = FireStoreService()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         self.navigationItem.title = "ChatRoom"
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.chatRoomList = self.fireStoreService.getChatRooms()!
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -24,7 +30,7 @@ class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableView
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        cell.textLabel!.text = chatRoomList[indexPath.row]
+        cell.textLabel!.text = chatRoomList[indexPath.row].getRoomName()
         return cell
     }
     

--- a/imahima/Controller/ChatRoomViewController.swift
+++ b/imahima/Controller/ChatRoomViewController.swift
@@ -21,6 +21,10 @@ class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        // Facebookの友人情報を取得
+        let userFriendsService = UserFriendsService()
+        userFriends = userFriendsService.getUserFriends()
+        
         self.chatRoomList = self.fireStoreService.getChatRooms()!
     }
     
@@ -30,7 +34,12 @@ class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableView
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        cell.textLabel!.text = chatRoomList[indexPath.row].getRoomName()
+        
+        let userId: String = chatRoomList[indexPath.row].getRoomName()
+        let roomName: String = self.userFriends.filter{ $0.id == userId }[0].name
+        
+        cell.textLabel!.text = roomName
+        
         return cell
     }
     

--- a/imahima/Controller/ChatRoomViewController.swift
+++ b/imahima/Controller/ChatRoomViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
-//    let chatRoomList = ["yugoto", "stakeshi"]
     var chatRoomList: Array<ChatRoom> = []
     var userFriends: Array<User> = []
     let fireStoreService = FireStoreService()
@@ -46,12 +45,16 @@ class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // セルの選択を解除
         tableView.deselectRow(at: indexPath, animated: true)
-        // 別の画面に遷移
-//        self.transitionToChat()
+        
+        let userId: String = chatRoomList[indexPath.row].getOtherMemberId()
+        let partner: User = self.userFriends.filter{ $0.id == userId }[0]
         
         let storyboard: UIStoryboard = UIStoryboard(name: "Chat", bundle: nil)//遷移先のStoryboardを設定
         let nextView = storyboard.instantiateViewController(withIdentifier: "Chat") as! ChatViewController//遷移先のViewControllerを設定
+        
         nextView.roomId = chatRoomList[indexPath.row].id
+        nextView.partner = partner
+        
         self.navigationController?.pushViewController(nextView, animated: true)//遷移する
     }
     

--- a/imahima/Controller/ChatRoomViewController.swift
+++ b/imahima/Controller/ChatRoomViewController.swift
@@ -35,7 +35,7 @@ class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
         
-        let userId: String = chatRoomList[indexPath.row].getRoomName()
+        let userId: String = chatRoomList[indexPath.row].getOtherMemberId()
         let roomName: String = self.userFriends.filter{ $0.id == userId }[0].name
         
         cell.textLabel!.text = roomName
@@ -51,6 +51,7 @@ class ChatRoomViewController: UIViewController, UITableViewDelegate, UITableView
         
         let storyboard: UIStoryboard = UIStoryboard(name: "Chat", bundle: nil)//遷移先のStoryboardを設定
         let nextView = storyboard.instantiateViewController(withIdentifier: "Chat") as! ChatViewController//遷移先のViewControllerを設定
+        nextView.roomId = chatRoomList[indexPath.row].id
         self.navigationController?.pushViewController(nextView, animated: true)//遷移する
     }
     

--- a/imahima/Controller/ChatViewController.swift
+++ b/imahima/Controller/ChatViewController.swift
@@ -13,6 +13,7 @@ import InputBarAccessoryView
 class ChatViewController: MessagesViewController {
     
     var messageList: [MockMessage] = []
+    let me: Me = Me.sharedInstance
     
     lazy var formatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -68,25 +69,40 @@ class ChatViewController: MessagesViewController {
         ]
     }
     
-    func createOtherMessage(text: String) -> MockMessage {
-        let attributedText = NSAttributedString(string: text, attributes: [.font: UIFont.systemFont(ofSize: 15),
-                                                                           .foregroundColor: UIColor.black])
-        return MockMessage(attributedText: attributedText, sender: otherSender() , messageId: UUID().uuidString, date: Date())
-    }
-    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
+    }
+}
+
+// メッセージのclass管理用のextension
+extension ChatViewController {
+    func createSelfMessage (text: String) -> MockMessage {
+        let attributedText = NSAttributedString(string: text, attributes: [.font: UIFont.systemFont(ofSize: 15),.foregroundColor: UIColor.white])
+        return MockMessage(attributedText: attributedText, sender: currentSender() as! Sender, messageId: UUID().uuidString, date: Date())
+    }
+    
+    func createSelfMessage (image: UIImage) -> MockMessage {
+        return MockMessage(image: image, sender: currentSender() as! Sender, messageId: UUID().uuidString, date: Date())
+    }
+    
+    func createOtherMessage(text: String) -> MockMessage {
+        let attributedText = NSAttributedString(string: text, attributes: [.font: UIFont.systemFont(ofSize: 15),.foregroundColor: UIColor.black])
+        return MockMessage(attributedText: attributedText, sender: otherSender() as! Sender , messageId: UUID().uuidString, date: Date())
+    }
+    
+    func createOtherMessage (image: UIImage) -> MockMessage {
+        return MockMessage(image: image, sender: otherSender() as! Sender , messageId: UUID().uuidString, date: Date())
     }
 }
 
 // DataSource
 extension ChatViewController: MessagesDataSource {
     func currentSender() -> SenderType {
-        return Sender(id: "123", displayName: "me")
+        return Sender(id: me.getId(), displayName: me.getName())
     }
     
-    func otherSender() -> Sender {
-        return Sender(id: "456", displayName: "you")
+    func otherSender(id: String = "hoge", displayName: String = "you") -> SenderType {
+        return Sender(id: id, displayName: displayName)
     }
     
     func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
@@ -197,15 +213,13 @@ extension ChatViewController: MessageInputBarDelegate {
         for component in inputBar.inputTextView.components {
             if let image = component as? UIImage {
 
-                let imageMessage = MockMessage(image: image, sender: currentSender() as! Sender, messageId: UUID().uuidString, date: Date())
+                let imageMessage = createSelfMessage(image: image)
                 messageList.append(imageMessage)
                 messagesCollectionView.insertSections([messageList.count - 1])
 
             } else if let text = component as? String {
 
-                let attributedText = NSAttributedString(string: text, attributes: [.font: UIFont.systemFont(ofSize: 15),
-                                                                                   .foregroundColor: UIColor.white])
-                let message = MockMessage(attributedText: attributedText, sender: currentSender() as! Sender, messageId: UUID().uuidString, date: Date())
+                let message = createSelfMessage(text: text)
                 messageList.append(message)
                 messagesCollectionView.insertSections([messageList.count - 1])
             }

--- a/imahima/Controller/ChatViewController.swift
+++ b/imahima/Controller/ChatViewController.swift
@@ -21,7 +21,6 @@ class ChatViewController: MessagesViewController {
     var messageList: [MockMessage] = []
     let me: Me = Me.sharedInstance
     let fireStoreService = FireStoreService()
-    var snapshotLisener: ListenerRegistration?
     
     lazy var formatter: DateFormatter = {
         let formatter = DateFormatter()

--- a/imahima/Controller/ChatViewController.swift
+++ b/imahima/Controller/ChatViewController.swift
@@ -10,9 +10,6 @@ import UIKit
 import MessageKit
 import InputBarAccessoryView
 
-import Firebase
-import FirebaseFirestore
-
 class ChatViewController: MessagesViewController {
     
     var roomId: String = ""

--- a/imahima/Model/ChatRoom.swift
+++ b/imahima/Model/ChatRoom.swift
@@ -11,12 +11,10 @@ import Foundation
 class ChatRoom {
     var id: String
     var members: Array<String>
-    var messages: [[String: Any]]
     
-    init(id: String, members: Array<String>, messages: [[String: Any]]) {
+    init(id: String, members: Array<String>) {
         self.id = id
         self.members = members
-        self.messages = messages
     }
     
     // me以外のmembersのidをroom名として返す

--- a/imahima/Model/ChatRoom.swift
+++ b/imahima/Model/ChatRoom.swift
@@ -1,0 +1,28 @@
+//
+//  ChatRoom.swift
+//  imahima
+//
+//  Created by Shota Takeshima on 2020/02/21.
+//  Copyright © 2020 後藤祐貴. All rights reserved.
+//
+
+import Foundation
+
+class ChatRoom {
+    var id: String
+    var members: Array<String>
+    var messages: [[String: Any]]
+    
+    init(id: String, members: Array<String>, messages: [[String: Any]]) {
+        self.id = id
+        self.members = members
+        self.messages = messages
+    }
+    
+    // me以外のmembersのidをroom名として返す
+    // [Extension]: 複数名部屋に所属する場合を考える
+    func getRoomName() -> String {
+        let me: Me = Me.sharedInstance
+        return self.members.filter{ $0 != me.getId() }[0]
+    }
+}

--- a/imahima/Model/ChatRoom.swift
+++ b/imahima/Model/ChatRoom.swift
@@ -17,9 +17,9 @@ class ChatRoom {
         self.members = members
     }
     
-    // me以外のmembersのidをroom名として返す
+    // me以外のmembersのidを返す
     // [Extension]: 複数名部屋に所属する場合を考える
-    func getRoomName() -> String {
+    func getOtherMemberId() -> String {
         let me: Me = Me.sharedInstance
         return self.members.filter{ $0 != me.getId() }[0]
     }

--- a/imahima/Model/FireStoreService.swift
+++ b/imahima/Model/FireStoreService.swift
@@ -129,7 +129,6 @@ class FireStoreService {
             } else {
                 if querySnapshot!.documents.count == 1 {
                     for document in querySnapshot!.documents {
-                        print("\(document.documentID) => \(document.data()))")
                         let doc = document.data() as NSDictionary
                         let id: String = document.documentID
                         let members: Array<String> = doc.object(forKey: "members") as? Array<String> ?? []
@@ -173,7 +172,7 @@ class FireStoreService {
                         messageList.append(MessageData(from: from, createdAt: createdAt, message: message))
                     }
                 } else {
-                    print("getChatRooms: no data exists")
+                    print("getMessageData: no data exists")
                 }
             }
             keepAlive = false
@@ -181,5 +180,28 @@ class FireStoreService {
         let runLoop = RunLoop.current
         while keepAlive && runLoop.run(mode: RunLoop.Mode.default, before: Date(timeIntervalSinceNow: 0.01)) {}
         return messageList
+    }
+    
+    /*
+     チャットの内容を追加する
+    */
+    func setMessageData(id: String, messageData: MessageData) {
+        print("call setMessageData")
+        
+        let dataStore = Firestore.firestore()
+        let resourse = dataStore.collection("chatrooms").document(id).collection("messages")
+        
+        resourse.addDocument(data: [
+            "from": messageData.from,
+            "createdAt": messageData.createdAt,
+            "message": messageData.message,
+        ]) { err in
+            if let err = err {
+                print("Error adding document: \(err)")
+                
+            } else {
+                print("setMessageData: Document added")
+            }
+        }
     }
 }

--- a/imahima/Model/FireStoreService.swift
+++ b/imahima/Model/FireStoreService.swift
@@ -129,12 +129,11 @@ class FireStoreService {
             } else {
                 if querySnapshot!.documents.count == 1 {
                     for document in querySnapshot!.documents {
-                        print("\(document.documentID) => \(document.data())")
+                        print("\(document.documentID) => \(document.data()))")
                         let doc = document.data() as NSDictionary
                         let id: String = document.documentID
                         let members: Array<String> = doc.object(forKey: "members") as? Array<String> ?? []
-                        let messages: Array<[String: Any]>  = doc.object(forKey: "messages") as? Array<[String: Any]> ?? []
-                        chatrooms.append(ChatRoom(id: id, members: members, messages: messages))
+                        chatrooms.append(ChatRoom(id: id, members: members))
                     }
                 } else {
                     print("getChatRooms: no data exists")

--- a/imahima/Model/FireStoreService.swift
+++ b/imahima/Model/FireStoreService.swift
@@ -145,4 +145,41 @@ class FireStoreService {
         while keepAlive && runLoop.run(mode: RunLoop.Mode.default, before: Date(timeIntervalSinceNow: 0.01)) {}
         return chatrooms
     }
+    
+    /*
+     チャットルームIDからチャットの内容を取り出す
+    */
+    func getMessageData(id: String) -> Array<MessageData>! {
+        print("call getMessageData")
+        
+        var keepAlive = true
+        
+        var messageList: Array<MessageData> = []
+        
+        let dataStore = Firestore.firestore()
+        let resourse = dataStore.collection("chatrooms").document(id).collection("messages")
+        
+        resourse.getDocuments() { (querySnapshot, err) in
+            if let err = err {
+                print("Error getting documents: \(err)")
+            } else {
+                if querySnapshot!.documents.count == 1 {
+                    for document in querySnapshot!.documents {
+                        print("\(document.documentID) => \(document.data()))")
+                        let doc = document.data() as NSDictionary
+                        let from: String = doc.object(forKey: "from") as! String
+                        let createdAt: String = doc.object(forKey: "createdAt") as! String
+                        let message: String = doc.object(forKey: "message") as! String
+                        messageList.append(MessageData(from: from, createdAt: createdAt, message: message))
+                    }
+                } else {
+                    print("getChatRooms: no data exists")
+                }
+            }
+            keepAlive = false
+        }
+        let runLoop = RunLoop.current
+        while keepAlive && runLoop.run(mode: RunLoop.Mode.default, before: Date(timeIntervalSinceNow: 0.01)) {}
+        return messageList
+    }
 }

--- a/imahima/Model/MessageData.swift
+++ b/imahima/Model/MessageData.swift
@@ -1,0 +1,23 @@
+//
+//  messageData.swift
+//  imahima
+//
+//  fireStoreで管理しているmessage用のモデル
+//
+//  Created by Shota Takeshima on 2020/03/12.
+//  Copyright © 2020 後藤祐貴. All rights reserved.
+//
+
+import Foundation
+
+class MessageData {
+    var from: String
+    var createdAt: String
+    var message: String
+    
+    init(from: String, createdAt: String, message: String) {
+        self.from = from
+        self.createdAt = createdAt
+        self.message = message
+    }
+}

--- a/imahima/Model/MockMessage.swift
+++ b/imahima/Model/MockMessage.swift
@@ -2,6 +2,8 @@
 //  MockMessage.swift
 //  imahima
 //
+//  MessageKitで管理する用ののモデル
+//
 //  Created by Shota Takeshima on 2019/12/11.
 //  Copyright © 2019 後藤祐貴. All rights reserved.
 //

--- a/imahima/Model/MockMessage.swift
+++ b/imahima/Model/MockMessage.swift
@@ -2,7 +2,7 @@
 //  MockMessage.swift
 //  imahima
 //
-//  MessageKitで管理する用ののモデル
+//  MessageKitで管理する用のモデル
 //
 //  Created by Shota Takeshima on 2019/12/11.
 //  Copyright © 2019 後藤祐貴. All rights reserved.


### PR DESCRIPTION
## 概要 
- ChatRoomをfirestoreから取得
  - ChatRoomVCで一覧表示
- ChatRoomタップでChat画面遷移
  - メッセージ内容をChatVCに連携、並びにリアルタイム同期
  - メッセージ内容をfirestoreにpush

#### chatrooms_sheme
- idは自動付与

|プロパティ  |型  |説明  |
|---|---|---|
|members  |Array<String>  |部屋に所属しているUserのid  |
|messages  |collection  |チャットメッセージのコレクション  |

#### messages_sheme
- idは自動付与

|プロパティ  |型  |説明  |
|---|---|---|
|from  |String  |送信者のid  |
|message  |String  |実際のテキスト  |
|createdAt  |String  |送信時間(TimeStamp) |
